### PR TITLE
Fix `genId` proc to support 32 bit platforms

### DIFF
--- a/src/netty.nim
+++ b/src/netty.nim
@@ -105,7 +105,7 @@ func hash*(x: Address): Hash =
   hash((x.host, x.port))
 
 func genId(reactor: Reactor): uint32 {.inline.} =
-  reactor.r.rand(uint32.high.int).uint32
+  reactor.r.rand(0u32..uint32.high).uint32
 
 func newConnection(reactor: Reactor, address: Address): Connection =
   result = Connection()


### PR DESCRIPTION
I ran into issues while using netty on a Raspberry Pi 4 with a 32bit OS installed.  The `genId` procedure is doing type conversions that are invalid on a 32bit OS.

This changes the way the `genId` uses `rand` so that it will work on 64 bit and 32 bit platforms.